### PR TITLE
Define UserIdentityService so it compiles

### DIFF
--- a/discogs/user_identity.go
+++ b/discogs/user_identity.go
@@ -1,0 +1,5 @@
+package discogs
+
+type UserIdentityService struct {
+	client *Client
+}


### PR DESCRIPTION
Fixes this error.

```
[gtkesh:...thub.com/go-discogs/discogs]$ go build *.go                                                                                     (master) 
# command-line-arguments
./discogs.go:32: undefined: UserIdentityService
```
